### PR TITLE
[Update|AAC] Tweak solution idea template to include WAF links instead of ACOM links

### DIFF
--- a/templates/org/aac/aac-example-workload-content.md
+++ b/templates/org/aac/aac-example-workload-content.md
@@ -30,7 +30,7 @@ The following workflow (or dataflow) corresponds to the above diagram:
 
 ### Components
 
-> A bullet list of components in the architecture (including all relevant Azure services) with links to the the Well-Archictected Framework service guide for the product.
+> A bullet list of components in the architecture (including all relevant Azure services) with links to the the Well-Architected Framework service guide for the product.
 >
 > - Why is each component there?
 > - What does it do and why was it necessary?
@@ -147,7 +147,7 @@ Performance efficiency is the ability of your workload to scale to meet the dema
 >
 > Start with the explanation text (same for every section), in italics. This makes it clear that Microsoft takes responsibility for the article (not the one contributor). Then include the "Principal authors" list and the "Other contributors" list, if there are additional contributors (all in plain text, not italics or bold). Link each contributor's name to the person's LinkedIn profile. After the name, place a pipe symbol ("|") with spaces, and then enter the person's title. We don't include the person's company, MVP status, or links to additional profiles (to minimize edits/updates). Implement this format:
 
-*This article is maintained by Microsoft. It was originally written by the following contributors.* 
+*This article is maintained by Microsoft. It was originally written by the following contributors.*
 
 Principal authors: > Only the primary authors. Listed alphabetically by last name. Use this format: Fname Lname. If the article gets rewritten, keep the original authors and add in the new one(s).
 

--- a/templates/org/aac/aac-solution-idea.md
+++ b/templates/org/aac/aac-solution-idea.md
@@ -15,7 +15,7 @@
 
 ![Diagram of the <solution name> architecture.](./images/<file-name>.png)
 
-> Under the architecture diagram, include this sentence and a link to the Visio file or the PowerPoint file: 
+> Under the architecture diagram, include this sentence and a link to the Visio file or the PowerPoint file:
 
 *Download a [Visio file](https://arch-center.azureedge.net/[file-name].vsdx) of this architecture.*
 
@@ -27,6 +27,7 @@
 > In this section, include a numbered list that annotates/describes the dataflow or workflow through the solution. Explain what each step does. Start from the user or external data source, and then follow the flow through the rest of the solution (as shown in the diagram).
 
 Examples:
+
 1. Admin 1 adds, updates, or deletes an entry in Admin 1's fork of the Microsoft 365 config file.
 2. Admin 1 commits and syncs the changes to Admin 1's forked repository.
 3. Admin 1 creates a pull request (PR) to merge the changes to the main repository.
@@ -34,49 +35,53 @@ Examples:
 
 ### Components
 
-> A bullet list of components in the architecture (including all relevant Azure services) with links to the product service pages. This is for lead generation (what business, marketing, and PG want). It helps drive revenue.
+> A bullet list of components in the architecture (including all relevant Azure services) with links to the the Well-Architected Framework service guide for the product.
+>
+> - Why is each component there?
+> - What does it do in this solution idea and why was it necessary?
+> - Link the name of the service (via embedded link) to the Azure Well-Architected service guide (if it exists), otherwise the service's product page. Be sure to exclude the localization part of the URL (such as "en-US/").
 
-> Why is each component there?
-> What does it do and why was it necessary?
-> Link the name of the service (via embedded link) to the service's product service page. Be sure to exclude the localization part of the URL (such as "en-US/").
+Example:
 
-Example: 
-* [Resource Groups][resource-groups] is a logical container for Azure resources.  We use resource groups to organize everything related to this project in the Azure console.
+- [Azure App Service](https://azure.microsoft.com/services/app-service) is a compute service that is specifically built to host web applications. In this architecture ….
+- [Azure OpenAI](/azure/well-architected/service-guides/azure-openai) is a …. In this architecture ….
+- [Log Analytics](/azure/well-architected/service-guides/azure-log-analytics) is a …. In this architecture ….
 
 ## Scenario details
 
 > This should be an explanation of the business problem and why this scenario was built to solve it.
->> What prompted them to solve the problem?
->> What services were used in building out this solution?
->> What does this example scenario show? What are the customer's goals?
-
-> What were the benefits of implementing the solution?
+>
+> - What prompted them to solve the problem?
+> - What services were used in building out this solution?
+> - What does this example scenario show? What are the customer's goals?
+> - What were the benefits of implementing the solution?
 
 ### Potential use cases
 
-> What industry is the customer in? Use the following industry keywords, when possible, to get the article into the proper search and filter results: retail, finance, manufacturing, healthcare, government, energy, telecommunications, education, automotive, nonprofit, game, media (media and entertainment), travel (includes hospitality, like restaurants), facilities (includes real estate), aircraft (includes aerospace and satellites), agriculture, and sports. 
->> Are there any other use cases or industries where this would be a fit?
->> How similar or different are they to what's in this article?
+> What industry is the customer in? Use the following industry keywords, when possible, to get the article into the proper search and filter results: retail, finance, manufacturing, healthcare, government, energy, telecommunications, education, automotive, nonprofit, game, media (media and entertainment), travel (includes hospitality, like restaurants), facilities (includes real estate), aircraft (includes aerospace and satellites), agriculture, and sports.
+>
+> - Are there any other use cases or industries where this would be a fit?
+> - How similar or different are they to what's in this article?
 
 ## Contributors
 
 > (Expected, but this section is optional if all the contributors would prefer to not include it)
-
-> Start with the explanation text (same for every section), in italics. This makes it clear that Microsoft takes responsibility for the article (not the one contributor). Then include the "Pricipal authors" list and the "Other contributors" list, if there are additional contributors (all in plain text, not italics or bold). Link each contributor's name to the person's LinkedIn profile. After the name, place a pipe symbol ("|") with spaces, and then enter the person's title. We don't include the person's company, MVP status, or links to additional profiles (to minimize edits/updates). Implement this format:
+>
+> Start with the explanation text (same for every section), in italics. This makes it clear that Microsoft takes responsibility for the article (not the one contributor). Then include the "Principal authors" list and the "Other contributors" list, if there are additional contributors (all in plain text, not italics or bold). Link each contributor's name to the person's LinkedIn profile. After the name, place a pipe symbol ("|") with spaces, and then enter the person's title. We don't include the person's company, MVP status, or links to additional profiles (to minimize edits/updates). Implement this format:
 
 *This article is maintained by Microsoft. It was originally written by the following contributors.*
 
 Principal authors: > Only the primary authors. Listed alphabetically by last name. Use this format: Fname Lname. If the article gets rewritten, keep the original authors and add in the new one(s).
 
- - [Author 1 Name](http://linkedin.com/ProfileURL) | Title, such as "Cloud Solution Architect"
- - [Author 2 Name](http://linkedin.com/ProfileURL) | Title, such as "Cloud Solution Architect"
- - > Continue for each primary author (even if there are 10 of them).
+- [Author 1 Name](https://linkedin.com/in/ProfileURL) | Title, such as "Cloud Solution Architect"
+- [Author 2 Name](https://linkedin.com/in/ProfileURL) | Title, such as "Cloud Solution Architect"
+- > Continue for each primary author (even if there are 10 of them).
 
 Other contributors: > (If applicable.) Include contributing (but not primary) authors, major editors (not minor edits), and technical reviewers. Listed alphabetically by last name. Use this format: Fname Lname. It's okay to add in newer contributors.
 
- - [Contributor 1 Name](http://linkedin.com/ProfileURL) | Title, such as "Cloud Solution Architect"
- - [Contributor 2 Name](http://linkedin.com/ProfileURL) | Title, such as "Cloud Solution Architect"
- - > Continue for each additional contributor (even if there are 10 of them).
+- [Contributor 1 Name](https://linkedin.com/in/ProfileURL) | Title, such as "Cloud Solution Architect"
+- [Contributor 2 Name](https://linkedin.com/in/ProfileURL) | Title, such as "Cloud Solution Architect"
+- > Continue for each additional contributor (even if there are 10 of them).
 
 *To see non-public LinkedIn profiles, sign in to LinkedIn.*
 
@@ -85,9 +90,10 @@ Other contributors: > (If applicable.) Include contributing (but not primary) au
 > Links to articles on Microsoft Learn. Could also be to appropriate sources outside of Learn, such as third-party documentation, GitHub repos, or an official technical blog post.
 
 Examples:
-* [Azure Kubernetes Service (AKS) documentation](/azure/aks)
-* [Azure Machine Learning documentation](/azure/machine-learning)
-* [What are Azure Cognitive Services?](/azure/cognitive-services/what-are-cognitive-services)
+
+- [Azure Kubernetes Service (AKS) documentation](/azure/aks)
+- [Azure Machine Learning documentation](/azure/machine-learning)
+- [What are Azure AI services?](/azure/ai-services/what-are-ai-services)
 
 ## Related resources
 
@@ -98,11 +104,11 @@ Examples:
 
 Related architecture guides:
 
-* [Artificial intelligence (AI) - Architectural overview](/azure/architecture/data-guide/big-data/ai-overview)
-* [Choosing a Microsoft cognitive services technology](/azure/architecture/data-guide/technology-choices/cognitive-services)
+- [Artificial intelligence (AI) - Architectural overview](/azure/architecture/data-guide/big-data/ai-overview)
+- [Choosing a Microsoft AI services technology](/azure/architecture/data-guide/technology-choices/cognitive-services)
 
 Fully deployable architectures:
 
-* [Chatbot for hotel reservations](/azure/architecture/example-scenario/ai/commerce-chatbot)
-* [Build an enterprise-grade conversational bot](/azure/architecture/reference-architectures/ai/conversational-bot)
-* [Speech-to-text conversion](/azure/architecture/reference-architectures/ai/speech-ai-ingestion)
+- [Chatbot for hotel reservations](/azure/architecture/example-scenario/ai/commerce-chatbot)
+- [Build an enterprise-grade conversational bot](/azure/architecture/reference-architectures/ai/conversational-bot)
+- [Speech-to-text conversion](/azure/architecture/reference-architectures/ai/speech-ai-ingestion)


### PR DESCRIPTION
- Components section needs to link to WAF not Acom - a WAF 2.0 initiative.
- Fixed LinkedIn links (http -> https + `/in`
- Minor formatting/linting tweaks
- Typo fix