### PR TITLE
AAC templates: Removing unwanted metadata

### DIFF
--- a/templates/org/aac/aac-architecture-guide-browse.yml
+++ b/templates/org/aac/aac-architecture-guide-browse.yml
@@ -11,7 +11,7 @@ metadata:
 azureCategories:
   - <List at least one category, as explained in the template instructions.>
 products:
-  - <List 1-5 products, as explained in the template instructions.>
+  - <List 1 to 5 products, as explained in the template instructions.>
 name: <Article title in sentence casing>
 summary: <Align with the template instructions for this content type.>
 thumbnailUrl: /azure/architecture/browse/thumbs/<file-name>.png

--- a/templates/org/aac/aac-architecture-guide-content-browse.md
+++ b/templates/org/aac/aac-architecture-guide-content-browse.md
@@ -1,6 +1,7 @@
 <!-- 
-- Don't add metadata to this Markdown file. Use the browser header template to create a YAML file that contains your metadata. 
-- Add a brief introductory paragraph with no heading. 
+Don't add metadata to this Markdown file.
+Use the browser header template to create a YAML file that contains your metadata. 
+Add a brief introductory paragraph with no heading. 
 -->
 
 ## Architecture

--- a/templates/org/aac/aac-architecture-guide-content-browse.md
+++ b/templates/org/aac/aac-architecture-guide-content-browse.md
@@ -1,7 +1,7 @@
 <!-- 
 Don't add metadata to this Markdown file.
 Use the browser header template to create a YAML file that contains your metadata. 
-Add a brief introductory paragraph with no heading. 
+Add a brief introductory paragraph with no heading.
 -->
 
 ## Architecture

--- a/templates/org/aac/aac-architecture-guide-content.md
+++ b/templates/org/aac/aac-architecture-guide-content.md
@@ -6,10 +6,6 @@ ms.author: <Contributor Microsoft alias>
 ms.date: <Date of publish or last freshness pass, in mm/dd/yyyy format>
 ms.topic: conceptual
 ms.subservice: architecture-guide
-products:
-  - <List 1-5 products, as explained in the template instructions.>
-categories:
-  - <List at least one category, as explained in the template instructions.>
 ---
 
 # <!-- Article title in sentence casing -->

--- a/templates/org/aac/aac-article-title-content.md
+++ b/templates/org/aac/aac-article-title-content.md
@@ -1,6 +1,7 @@
 <!-- 
-- Don't add metadata to this Markdown file. Use the browser header template to create a YAML file that contains your metadata. 
-- Add a brief introductory paragraph with no heading. 
+Don't add metadata to this Markdown file.
+Use the browser header template to create a YAML file that contains your metadata. 
+Add a brief introductory paragraph with no heading. 
 -->
 
 ## Architecture
@@ -26,8 +27,9 @@ The following dataflow corresponds to the previous diagram:
 ### Components
 
 <!-- 
-- Add a bulleted list of all components in the architecture. 
-- Where possible, link to the component's Well-Architected Framework service guide. Alternatively, link to the product's documentation page.
+Add a bulleted list of all components in the architecture.
+Where possible, link to the component's Well-Architected Framework service guide.
+Alternatively, link to the product's documentation page.
 -->
 
 ### Alternatives
@@ -79,9 +81,9 @@ Security provides assurances against deliberate attacks and the misuse of your v
 Cost Optimization focuses on ways to reduce unnecessary expenses and improve operational efficiencies. For more information, see [Design review checklist for Cost Optimization](/azure/well-architected/cost-optimization/checklist).
 
 <!-- 
-- Explain Cost Optimization considerations. 
-- Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated. 
-- Include the major cost-driving components, a typical scale or throughput, and recommended SKUs. 
+Explain Cost Optimization considerations. 
+Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated. 
+Include the major cost-driving components, a typical scale or throughput, and recommended SKUs. 
 -->
 
 ### Operational Excellence
@@ -102,9 +104,11 @@ Performance Efficiency refers to your workload's ability to scale to meet user d
 
 ## Deploy this scenario
 
-<!-- This section is required. 
+<!-- 
+This section is required. 
 Link to a template or script that explains how to deploy the solution. 
-Include source code, deployment code, and instructions for how to test the scenario. -->
+Include source code, deployment code, and instructions for how to test the scenario. 
+-->
 
 ## Contributors
 

--- a/templates/org/aac/aac-article-title-content.md
+++ b/templates/org/aac/aac-article-title-content.md
@@ -100,6 +100,12 @@ Performance Efficiency refers to your workload's ability to scale to meet user d
 
 <!-- Explain key performance considerations, beyond the typical. -->
 
+## Deploy this scenario
+
+<!-- This section is required. 
+Link to a template or script that explains how to deploy the solution. 
+Include source code, deployment code, and instructions for how to test the scenario. -->
+
 ## Contributors
 
 <!-- This section is expected but optional if the contributors prefer to omit it. -->

--- a/templates/org/aac/aac-article-title-content.md
+++ b/templates/org/aac/aac-article-title-content.md
@@ -1,7 +1,7 @@
 <!-- 
 Don't add metadata to this Markdown file.
 Use the browser header template to create a YAML file that contains your metadata. 
-Add a brief introductory paragraph with no heading. 
+Add a brief introductory paragraph with no heading.
 -->
 
 ## Architecture
@@ -80,10 +80,10 @@ Security provides assurances against deliberate attacks and the misuse of your v
 
 Cost Optimization focuses on ways to reduce unnecessary expenses and improve operational efficiencies. For more information, see [Design review checklist for Cost Optimization](/azure/well-architected/cost-optimization/checklist).
 
-<!-- 
-Explain Cost Optimization considerations. 
-Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated. 
-Include the major cost-driving components, a typical scale or throughput, and recommended SKUs. 
+<!--
+Explain Cost Optimization considerations.
+Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated.
+Include the major cost-driving components, a typical scale or throughput, and recommended SKUs.
 -->
 
 ### Operational Excellence
@@ -104,10 +104,10 @@ Performance Efficiency refers to your workload's ability to scale to meet user d
 
 ## Deploy this scenario
 
-<!-- 
-This section is required. 
-Link to a template or script that explains how to deploy the solution. 
-Include source code, deployment code, and instructions for how to test the scenario. 
+<!--
+This section is required.
+Link to a GitHub-hosted template or script that explains how to deploy the solution.
+The repo will contain all of the source code, deployment code, and instructions for how to try the scenario in the customer's own subscription.
 -->
 
 ## Contributors

--- a/templates/org/aac/aac-browser-header.yml
+++ b/templates/org/aac/aac-browser-header.yml
@@ -10,7 +10,7 @@ metadata:
 azureCategories:
   - <List at least one category, as explained in the browser header template instructions.>
 products:
-  - <List 1-5 products, as explained in the browser header template instructions.>
+  - <List 1 to 5 products, as explained in the browser header template instructions.>
 name: <Article title in sentence casing>
 summary: <Align with the browser header template instructions.>
 thumbnailUrl: /azure/architecture/browse/thumbs/<file-name>.png

--- a/templates/org/aac/aac-design-pattern.md
+++ b/templates/org/aac/aac-design-pattern.md
@@ -40,8 +40,8 @@ This pattern might not be suitable when:
 Evaluate how to use <!--insert name of pattern--> in a workload's design to address the goals and principles covered in the [Azure Well-Architected Framework pillars](/azure/well-architected/pillars). The following table provides guidance about how this pattern supports the goals of each pillar.
 
 <!--
-- In the following table, include only the relevant rows. 
-- Don't add information that's not part of the Well-Architected Framework pillars. 
+In the following table, include only the relevant rows. 
+Don't add information that's not part of the Well-Architected Framework pillars. 
 -->
 
 | Pillar | How this pattern supports pillar goals |

--- a/templates/org/aac/aac-design-pattern.md
+++ b/templates/org/aac/aac-design-pattern.md
@@ -40,8 +40,8 @@ This pattern might not be suitable when:
 Evaluate how to use <!--insert name of pattern--> in a workload's design to address the goals and principles covered in the [Azure Well-Architected Framework pillars](/azure/well-architected/pillars). The following table provides guidance about how this pattern supports the goals of each pillar.
 
 <!--
-In the following table, include only the relevant rows. 
-Don't add information that's not part of the Well-Architected Framework pillars. 
+In the following table, include only the relevant rows.
+Don't add information that's not part of the Well-Architected Framework pillars.
 -->
 
 | Pillar | How this pattern supports pillar goals |

--- a/templates/org/aac/aac-design-pattern.md
+++ b/templates/org/aac/aac-design-pattern.md
@@ -6,10 +6,6 @@ ms.author: <Contributor Microsoft alias>
 ms.date: <Date of publish or last freshness pass, in mm/dd/yyyy format>
 ms.topic: design-pattern
 ms.subservice: design-pattern
-products:
-  - <List 1-5 products, as explained in the template instructions.>
-categories:
-  - <List at least one category, as explained in the template instructions.>
 ---
 # <!-- Article title in sentence casing -->
 

--- a/templates/org/aac/aac-example-workload-content.md
+++ b/templates/org/aac/aac-example-workload-content.md
@@ -1,6 +1,7 @@
 <!-- 
-- Don't add metadata to this Markdown file. Use the browser header template to create a YAML file for your metadata. 
-- Add a brief introductory paragraph with no heading. 
+Don't add metadata to this Markdown file.
+Use the browser header template to create a YAML file for your metadata.
+Add a brief introductory paragraph with no heading.
 -->
 
 ## Architecture
@@ -26,8 +27,9 @@ The following dataflow corresponds to the previous diagram:
 ### Components
 
 <!-- 
-- Add a bulleted list of all components in the architecture. 
-- Where possible, link to the component's Well-Architected Framework service guide. Alternatively, link to the product's documentation page.
+Add a bulleted list of all components in the architecture.
+Where possible, link to the component's Well-Architected Framework service guide.
+Alternatively, link to the product's documentation page.
 -->
 
 ### Alternatives
@@ -77,9 +79,9 @@ Security provides assurances against deliberate attacks and the misuse of your v
 Cost Optimization focuses on ways to reduce unnecessary expenses and improve operational efficiencies. For more information, see [Design review checklist for Cost Optimization](/azure/well-architected/cost-optimization/checklist).
 
 <!-- 
-- Explain Cost Optimization considerations. 
-- Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated. 
-- Include the major cost-driving components, a typical scale or throughput, and recommended SKUs. 
+Explain Cost Optimization considerations. 
+Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated. 
+Include the major cost-driving components, a typical scale or throughput, and recommended SKUs. 
 -->
 
 ### Operational Excellence
@@ -98,6 +100,13 @@ Performance Efficiency refers to your workload's ability to scale to meet user d
 
 <!-- Explain key performance considerations, beyond the typical. -->
 
+## Deploy this scenario
+
+<!-- This section is expected but optional if the contributors prefer to omit it.
+Link to a template or script that explains how to deploy the workload.
+Include source code, deployment code, and instructions for how to test the scenario. 
+-->
+
 ## Contributors
 
 <!-- This section is expected but optional if the contributors prefer to omit it. -->
@@ -114,8 +123,8 @@ Principal authors:
 Other contributors:
 
 <!--
-- This section is optional. 
-- List contributors and technical reviewers. 
+This section is optional. 
+List contributors and technical reviewers. 
 -->
 
 - [Contributor 1 Name](https://www.linkedin.com/in/ProfileURL/) | Title, such as "Cloud Solution Architect"

--- a/templates/org/aac/aac-example-workload-content.md
+++ b/templates/org/aac/aac-example-workload-content.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Don't add metadata to this Markdown file.
 Use the browser header template to create a YAML file for your metadata.
 Add a brief introductory paragraph with no heading.
@@ -78,10 +78,10 @@ Security provides assurances against deliberate attacks and the misuse of your v
 
 Cost Optimization focuses on ways to reduce unnecessary expenses and improve operational efficiencies. For more information, see [Design review checklist for Cost Optimization](/azure/well-architected/cost-optimization/checklist).
 
-<!-- 
-Explain Cost Optimization considerations. 
-Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated. 
-Include the major cost-driving components, a typical scale or throughput, and recommended SKUs. 
+<!--
+Explain Cost Optimization considerations.
+Link to the pricing calculator (https://azure.microsoft.com/pricing/calculator), with this architecture prepopulated.
+Include the major cost-driving components, a typical scale or throughput, and recommended SKUs.
 -->
 
 ### Operational Excellence
@@ -102,9 +102,10 @@ Performance Efficiency refers to your workload's ability to scale to meet user d
 
 ## Deploy this scenario
 
-<!-- This section is expected but optional if the contributors prefer to omit it.
-Link to a template or script that explains how to deploy the workload.
-Include source code, deployment code, and instructions for how to test the scenario. 
+<!--
+This section is expected but optional if the contributors prefer to omit it.
+Link to a GitHub-hosted template or script that explains how to deploy the workload.
+The repo will contain all of the source code, deployment code, and instructions for how to try the scenario in the customer's own subscription.
 -->
 
 ## Contributors
@@ -123,8 +124,8 @@ Principal authors:
 Other contributors:
 
 <!--
-This section is optional. 
-List contributors and technical reviewers. 
+This section is optional.
+List contributors and technical reviewers.
 -->
 
 - [Contributor 1 Name](https://www.linkedin.com/in/ProfileURL/) | Title, such as "Cloud Solution Architect"

--- a/templates/org/aac/aac-solution-idea.md
+++ b/templates/org/aac/aac-solution-idea.md
@@ -1,7 +1,7 @@
-<!-- 
+<!--
 Don't add metadata to this Markdown file.
 Use the browser header template to create a YAML file that contains your metadata.
-Add a brief introductory paragraph with no heading. 
+Add a brief introductory paragraph with no heading.
 -->
 
 ## Architecture
@@ -12,9 +12,9 @@ Add a brief introductory paragraph with no heading.
    <Long description that ends with a period.>
 :::image-end:::
 
-<!-- 
-Under the architecture diagram, link to the Visio or PowerPoint file. 
-The link will work after the AAC team uploads your Visio or PowerPoint file to the Azure CDN. 
+<!--
+Under the architecture diagram, link to the Visio or PowerPoint file.
+The link will work after the AAC team uploads your Visio or PowerPoint file to the Microsoft Learn CDN.
 -->
 
 *Download a [Visio file](https://arch-center.azureedge.net/<file-name>.vsdx) of this architecture.*
@@ -30,7 +30,7 @@ The following dataflow corresponds to the previous diagram:
 ### Components
 
 <!-- 
-Add a bulleted list of all components in the architecture. 
+Add a bulleted list of all components in the architecture.
 Where possible, link to the component's Well-Architected Framework service guide.
 Alternatively, link to the product's overview page on learn.microsoft.com.
 -->
@@ -59,8 +59,8 @@ Principal authors:
 Other contributors:
 
 <!--
-This section is optional. 
-List contributors and technical reviewers. 
+This section is optional.
+List contributors and technical reviewers.
 -->
 
 - [Contributor 1 Name](https://www.linkedin.com/in/ProfileURL/) | Title, such as "Cloud Solution Architect"

--- a/templates/org/aac/aac-solution-idea.md
+++ b/templates/org/aac/aac-solution-idea.md
@@ -1,6 +1,7 @@
 <!-- 
-- Don't add metadata to this Markdown file. Use the browser header template to create a YAML file that contains your metadata. 
-- Add a brief introductory paragraph with no heading. 
+Don't add metadata to this Markdown file.
+Use the browser header template to create a YAML file that contains your metadata.
+Add a brief introductory paragraph with no heading. 
 -->
 
 ## Architecture
@@ -11,7 +12,10 @@
    <Long description that ends with a period.>
 :::image-end:::
 
-<!-- Under the architecture diagram, link to the Visio or PowerPoint file. The link will work after the AAC team uploads your Visio or PowerPoint file to the Azure CDN. -->
+<!-- 
+Under the architecture diagram, link to the Visio or PowerPoint file. 
+The link will work after the AAC team uploads your Visio or PowerPoint file to the Azure CDN. 
+-->
 
 *Download a [Visio file](https://arch-center.azureedge.net/<file-name>.vsdx) of this architecture.*
 
@@ -26,8 +30,9 @@ The following dataflow corresponds to the previous diagram:
 ### Components
 
 <!-- 
-- Add a bulleted list of all components in the architecture. 
-- Where possible, link to the component's Well-Architected Framework service guide. Alternatively, link to the product's overview page on learn.microsoft.com.
+Add a bulleted list of all components in the architecture. 
+Where possible, link to the component's Well-Architected Framework service guide.
+Alternatively, link to the product's overview page on learn.microsoft.com.
 -->
 
 ## Scenario details
@@ -54,8 +59,8 @@ Principal authors:
 Other contributors:
 
 <!--
-- This section is optional. 
-- List contributors and technical reviewers. 
+This section is optional. 
+List contributors and technical reviewers. 
 -->
 
 - [Contributor 1 Name](https://www.linkedin.com/in/ProfileURL/) | Title, such as "Cloud Solution Architect"


### PR DESCRIPTION
Remove product and categories metadata for MD-only templates. 
Add "Deploy this scenario" section to two templates.
Adjust formatting to reduce need to scroll right to read template instructions in contributor guide.